### PR TITLE
fix: remove Connection modes from DB path in export_db function

### DIFF
--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -29,3 +29,4 @@ thiserror = "2.0.17"
 tracing = "0.1.44"
 tracing-subscriber = "0.3.22"
 validator = { version = "0.20.0", features = ["derive"] }
+url = "2.5.7"


### PR DESCRIPTION
## Summary

Fix database export failure when `DATABASE_URL` is not set and improve Swagger UI organization by properly tagging the registration endpoint.

## Description

### Database export fix

When `DATABASE_URL` is not defined, the application falls back to a default SQLite URL that includes query parameters (`sqlite:payme.db?mode=rwc`).  
The `export_db` handler was attempting to use this value directly as a filesystem path after stripping only the `sqlite:` prefix, which resulted in an invalid path (`payme.db?mode=rwc`) and caused the export to fail.

This PR fixes the issue by also removing the `?mode=rwc` query parameter, ensuring the resolved value is a valid SQLite database file path before calling `tokio::fs::read`.

### Swagger UI improvement

The `register` endpoint was missing a tag in its `utoipa::path` annotation, causing it to appear in an incorrect or default group in Swagger UI.  
A tag (`Auth`) was added to ensure the endpoint is grouped correctly and improves API documentation clarity.

## What Changed

- Sanitized the derived database path in `export_db`
- Removed SQLite query parameters (`?mode=rwc`) when resolving the file path
- Added a Swagger tag to the register endpoint for proper grouping in Swagger UI

## Result

- Database export works reliably when `DATABASE_URL` is unset
- Swagger UI now displays the register endpoint under the correct **Auth** group
