### PR TITLE
refactor: replace `StatusCode` errors with `PaymeError` type

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -1236,6 +1236,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,10 +1399,13 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "thiserror",
  "time",
  "tokio",
  "tower",
  "tower-http",
+ "tracing",
+ "tracing-subscriber",
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
@@ -1827,6 +1839,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,6 +2199,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2369,6 +2399,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2486,6 +2542,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -4,20 +4,23 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-axum = { version = "*", features = ["macros"] }
-axum-extra = { version = "*", features = ["cookie"] }
-tokio = { version = "*", features = ["full"] }
-tower = "*"
-tower-http = { version = "*", features = ["cors", "fs"] }
-serde = { version = "*", features = ["derive"] }
-serde_json = "*"
-sqlx = { version = "*", features = ["runtime-tokio", "sqlite", "chrono"] }
-argon2 = "*"
-jsonwebtoken = { version = "*", features = ["rust_crypto"] }
-chrono = { version = "*", features = ["serde"] }
-printpdf = "0.7"
-uuid = { version = "*", features = ["v4"] }
-dotenvy = "*"
-time = "*"
+axum = { version = "0.8.8", features = ["macros"] }
+axum-extra = { version = "0.12.5", features = ["cookie"] }
+tokio = { version = "1.49.0", features = ["full"] }
+tower = "0.5.2"
+tower-http = { version = "0.6.8", features = ["cors", "fs"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.148"
+sqlx = { version = "0.8.6", features = ["runtime-tokio", "sqlite", "chrono"] }
+argon2 = "0.5.3"
+jsonwebtoken = { version = "10.2.0", features = ["rust_crypto"] }
+chrono = { version = "0.4.42", features = ["serde"] }
+printpdf = "0.7.0"
+uuid = { version = "1.19.0", features = ["v4"] }
+dotenvy = "0.15.7"
+time = "0.3.44"
 utoipa = { version = "5.4.0", features = ["axum_extras", "chrono" ] }
 utoipa-swagger-ui = { version = "9.0.2", features = ["axum"] }
+thiserror = "2.0.17"
+tracing = "0.1.44"
+tracing-subscriber = "0.3.22"

--- a/backend/src/error.rs
+++ b/backend/src/error.rs
@@ -1,0 +1,37 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum PaymeError {
+    #[error("Database error: {0}")]
+    Database(#[from] sqlx::Error),
+
+    #[error("Not found")]
+    NotFound,
+
+    #[error("Unauthorized")]
+    Unauthorized,
+
+    #[error("Bad request: {0}")]
+    BadRequest(String),
+
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+impl IntoResponse for PaymeError {
+    fn into_response(self) -> Response {
+        let status = match &self {
+            PaymeError::Database(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            PaymeError::NotFound => StatusCode::NOT_FOUND,
+            PaymeError::Unauthorized => StatusCode::UNAUTHORIZED,
+            PaymeError::BadRequest(_) => StatusCode::BAD_REQUEST,
+            PaymeError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        tracing::error!("{self}");
+        status.into_response()
+    }
+}

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod db;
+mod error;
 mod handlers;
 mod middleware;
 mod models;
@@ -23,6 +24,7 @@ use utoipa_swagger_ui::SwaggerUi;
 
 #[tokio::main]
 async fn main() {
+    tracing_subscriber::fmt::init();
     let config = Config::from_env();
     let pool = db::create_pool(&config.database_url)
         .await
@@ -119,6 +121,8 @@ async fn main() {
     let addr = format!("0.0.0.0:{}", config.port);
     println!("Server running on {}", addr);
 
-    let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
-    axum::serve(listener, app).await.unwrap();
+    let listener = tokio::net::TcpListener::bind(&addr)
+        .await
+        .expect("Failed to bind to address");
+    axum::serve(listener, app).await.expect("Server error");
 }


### PR DESCRIPTION
- Add `thiserror` + `tracing` for structured error handling
- Create `PaymeError` enum with `Database`, `NotFound`, `Unauthorized`, `BadRequest`, `Internal` variants
- Update all handlers to use `PaymeError` instead of raw `StatusCode`
- Remove`map_err(|_|...)` calls that swallowed error context
- Fix date parsing in `months.rs` to use `chrono` directly (no more unwrap woohoo)
- Replace `unwrap()` with `expect()` in `main.rs` for startup errors
- Errors now logged with `tracing` before returning HTTP status