### PR TITLE
fix: remove broken users_new migration and consolidate schema

### DIFF
--- a/backend/src/db/mod.rs
+++ b/backend/src/db/mod.rs
@@ -16,6 +16,7 @@ pub async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
             username TEXT NOT NULL UNIQUE,
             password_hash TEXT NOT NULL,
             savings REAL NOT NULL DEFAULT 0,
+            retirement_savings REAL NOT NULL DEFAULT 0,
             created_at TEXT NOT NULL DEFAULT (datetime('now'))
         )
         "#,
@@ -29,58 +30,6 @@ pub async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::Error> {
         .ok();
 
     sqlx::query("ALTER TABLE users ADD COLUMN retirement_savings REAL NOT NULL DEFAULT 0")
-        .execute(pool)
-        .await
-        .ok();
-
-    sqlx::query(
-        r#"
-        CREATE TABLE IF NOT EXISTS users_new (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            username TEXT NOT NULL UNIQUE,
-            password_hash TEXT NOT NULL,
-            savings REAL NOT NULL DEFAULT 0,
-            retirement_savings REAL NOT NULL DEFAULT 0,
-            created_at TEXT NOT NULL DEFAULT (datetime('now'))
-        )
-        "#,
-    )
-    .execute(pool)
-    .await
-    .ok();
-
-    sqlx::query(
-        r#"
-        INSERT OR IGNORE INTO users_new (id, username, password_hash, savings, retirement_savings, created_at)
-        SELECT id, username, password_hash, CAST(savings AS REAL), CAST(retirement_savings AS REAL), created_at
-        FROM users
-        "#,
-    )
-    .execute(pool)
-    .await
-    .ok();
-
-    sqlx::query("DROP TABLE IF EXISTS users_old")
-        .execute(pool)
-        .await
-        .ok();
-
-    sqlx::query("ALTER TABLE users RENAME TO users_old")
-        .execute(pool)
-        .await
-        .ok();
-
-    sqlx::query("ALTER TABLE users_new RENAME TO users")
-        .execute(pool)
-        .await
-        .ok();
-
-    sqlx::query("DROP TABLE IF EXISTS users_old")
-        .execute(pool)
-        .await
-        .ok();
-
-    sqlx::query("UPDATE users SET retirement_savings = roth_ira WHERE retirement_savings = 0 AND roth_ira IS NOT NULL AND roth_ira > 0")
         .execute(pool)
         .await
         .ok();


### PR DESCRIPTION
## Problem
Fresh database initialization was failing with "no such table: users" error due to broken migration logic.

- Remove problematic ALTER TABLE RENAME operations that silently failed
- Add retirement_savings column to initial users table creation
- Keep ALTER TABLE ADD COLUMN for backwards compatibility
- Fixes \"no such table: users\" error on fresh database initialization"