### PR TITLE
feat: summary + freely navigate months 

### DIFF
--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -35,12 +35,14 @@ pub fn create_app(pool: SqlitePool) -> Router {
         .route("/api/auth/clear-data", delete(auth::clear_all_data))
         .route("/api/export", get(auth::export_db))
         .route("/api/months", get(months::list_months))
+        .route("/api/months", post(months::create_month))
         .route(
             "/api/months/current",
             get(months::get_or_create_current_month),
         )
         .route("/api/months/{id}", get(months::get_month))
         .route("/api/months/{id}/close", post(months::close_month))
+        .route("/api/months/{id}/reopen", post(months::reopen_month))
         .route("/api/months/{id}/pdf", get(months::get_month_pdf))
         .route(
             "/api/fixed-expenses",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "payme-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "html2canvas": "^1.4.1",
         "lucide-react": "*",
         "react": "*",
         "react-dom": "*",
@@ -2197,6 +2198,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.17",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.17.tgz",
@@ -2356,6 +2366,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/csstype": {
@@ -2986,6 +3005,19 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/ignore": {
@@ -3956,6 +3988,15 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -4091,6 +4132,15 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/victory-vendor": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,25 +10,25 @@
     "lint": "eslint src --ext .ts,.tsx --max-warnings 0"
   },
   "dependencies": {
+    "html2canvas": "^1.4.1",
     "lucide-react": "*",
     "react": "*",
     "react-dom": "*",
     "recharts": "*"
   },
   "devDependencies": {
+    "@eslint/js": "*",
     "@tailwindcss/vite": "*",
     "@types/react": "*",
     "@types/react-dom": "*",
     "@vitejs/plugin-react": "*",
     "eslint": "*",
-    "@eslint/js": "*",
-    "typescript-eslint": "*",
     "eslint-plugin-react-hooks": "*",
     "eslint-plugin-react-refresh": "*",
     "globals": "*",
     "tailwindcss": "*",
     "typescript": "*",
+    "typescript-eslint": "*",
     "vite": "*"
   }
 }
-

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,12 +4,15 @@ import { Login } from "./pages/Login";
 import { Register } from "./pages/Register";
 import { Dashboard } from "./pages/Dashboard";
 import { Settings } from "./pages/Settings";
+import { SummaryPage } from "./pages/Summary";
 import { Loader2 } from "lucide-react";
 
 export default function App() {
   const { user, loading } = useAuth();
   const [showRegister, setShowRegister] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
+  const [showSummary, setShowSummary] = useState(false);
+  const [summaryMonthId, setSummaryMonthId] = useState<number | null>(null);
 
   if (loading) {
     return (
@@ -31,6 +34,23 @@ export default function App() {
     return <Settings onBack={() => setShowSettings(false)} />;
   }
 
-  return <Dashboard onSettingsClick={() => setShowSettings(true)} />;
+  if (showSummary) {
+    return (
+      <SummaryPage
+        onBack={() => setShowSummary(false)}
+        initialMonthId={summaryMonthId}
+      />
+    );
+  }
+
+  return (
+    <Dashboard
+      onSettingsClick={() => setShowSettings(true)}
+      onSummaryClick={(monthId) => {
+        setSummaryMonthId(monthId ?? null);
+        setShowSummary(true);
+      }}
+    />
+  );
 }
 

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -59,7 +59,13 @@ export const api = {
     list: () => request<Month[]>("/months"),
     current: () => request<MonthSummary>("/months/current"),
     get: (id: number) => request<MonthSummary>(`/months/${id}`),
+    create: (year: number, month: number) =>
+      request<MonthSummary>("/months", {
+        method: "POST",
+        body: JSON.stringify({ year, month }),
+      }),
     close: (id: number) => request<Month>(`/months/${id}/close`, { method: "POST" }),
+    reopen: (id: number) => request<Month>(`/months/${id}/reopen`, { method: "POST" }),
     downloadPdf: async (id: number) => {
       const response = await fetch(`${BASE_URL}/months/${id}/pdf`, {
         credentials: "include",

--- a/frontend/src/components/MonthNav.tsx
+++ b/frontend/src/components/MonthNav.tsx
@@ -1,4 +1,5 @@
-import { ChevronLeft, ChevronRight, FileDown, Lock } from "lucide-react";
+import { useState } from "react";
+import { ChevronLeft, ChevronRight, Lock, Calendar, PieChart } from "lucide-react";
 import { Month } from "../api/client";
 import { Button } from "./ui/Button";
 
@@ -6,8 +7,10 @@ interface MonthNavProps {
   months: Month[];
   selectedMonthId: number | null;
   onSelect: (id: number) => void;
+  onCreateMonth: (year: number, month: number) => void;
   onClose: () => void;
-  onDownloadPdf: () => void;
+  onReopen: () => void;
+  onSummary: () => void;
 }
 
 const MONTH_NAMES = [
@@ -15,33 +18,88 @@ const MONTH_NAMES = [
   "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ];
 
+const FULL_MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
 export function MonthNav({
   months,
   selectedMonthId,
   onSelect,
+  onCreateMonth,
   onClose,
-  onDownloadPdf,
+  onReopen,
+  onSummary,
 }: MonthNavProps) {
+  const [showPicker, setShowPicker] = useState(false);
+  const [pickerYear, setPickerYear] = useState(new Date().getFullYear());
+  
   const selectedMonth = months.find((m) => m.id === selectedMonthId);
-  const currentIndex = months.findIndex((m) => m.id === selectedMonthId);
 
-  const now = new Date();
-  const isCurrentCalendarMonth =
-    selectedMonth?.year === now.getFullYear() &&
-    selectedMonth?.month === now.getMonth() + 1;
-  const isLastDay = now.getDate() === new Date(now.getFullYear(), now.getMonth() + 1, 0).getDate();
-  const canClose = isCurrentCalendarMonth && isLastDay && !selectedMonth?.is_closed;
+  const canClose = !selectedMonth?.is_closed;
+
+  const getPrevMonth = () => {
+    if (!selectedMonth) return null;
+    let prevYear = selectedMonth.year;
+    let prevMonth = selectedMonth.month - 1;
+    if (prevMonth < 1) {
+      prevMonth = 12;
+      prevYear -= 1;
+    }
+    return { year: prevYear, month: prevMonth };
+  };
+
+  const getNextMonth = () => {
+    if (!selectedMonth) return null;
+    let nextYear = selectedMonth.year;
+    let nextMonth = selectedMonth.month + 1;
+    if (nextMonth > 12) {
+      nextMonth = 1;
+      nextYear += 1;
+    }
+    return { year: nextYear, month: nextMonth };
+  };
 
   const goPrev = () => {
-    if (currentIndex < months.length - 1) {
-      onSelect(months[currentIndex + 1].id);
+    const prev = getPrevMonth();
+    if (!prev) return;
+    
+    const existingMonth = months.find(m => m.year === prev.year && m.month === prev.month);
+    if (existingMonth) {
+      onSelect(existingMonth.id);
+    } else {
+      onCreateMonth(prev.year, prev.month);
     }
   };
 
   const goNext = () => {
-    if (currentIndex > 0) {
-      onSelect(months[currentIndex - 1].id);
+    const next = getNextMonth();
+    if (!next) return;
+    
+    const existingMonth = months.find(m => m.year === next.year && m.month === next.month);
+    if (existingMonth) {
+      onSelect(existingMonth.id);
+    } else {
+      onCreateMonth(next.year, next.month);
     }
+  };
+
+  const handleMonthSelect = (month: number) => {
+    const existingMonth = months.find(m => m.year === pickerYear && m.month === month);
+    if (existingMonth) {
+      onSelect(existingMonth.id);
+    } else {
+      onCreateMonth(pickerYear, month);
+    }
+    setShowPicker(false);
+  };
+
+  const openPicker = () => {
+    if (selectedMonth) {
+      setPickerYear(selectedMonth.year);
+    }
+    setShowPicker(true);
   };
 
   if (!selectedMonth) return null;
@@ -51,15 +109,18 @@ export function MonthNav({
       <div className="flex items-center gap-2 sm:gap-4">
         <button
           onClick={goPrev}
-          disabled={currentIndex >= months.length - 1}
-          className="p-2 hover:bg-sand-200 dark:hover:bg-charcoal-800 disabled:opacity-30 transition-colors touch-manipulation"
+          className="p-2 hover:bg-sand-200 dark:hover:bg-charcoal-800 transition-colors touch-manipulation"
           aria-label="Previous month"
         >
           <ChevronLeft size={20} />
         </button>
-        <div className="text-center">
-          <div className="text-xl sm:text-2xl font-semibold text-charcoal-900 dark:text-sand-50">
+        <button
+          onClick={openPicker}
+          className="text-center hover:bg-sand-200 dark:hover:bg-charcoal-800 px-3 py-1 rounded-lg transition-colors"
+        >
+          <div className="text-xl sm:text-2xl font-semibold text-charcoal-900 dark:text-sand-50 flex items-center gap-2 justify-center">
             {MONTH_NAMES[selectedMonth.month - 1]} {selectedMonth.year}
+            <Calendar size={16} className="text-charcoal-400" />
           </div>
           <div className="text-xs text-charcoal-500 dark:text-charcoal-400 flex items-center justify-center gap-1">
             {selectedMonth.is_closed ? (
@@ -71,11 +132,10 @@ export function MonthNav({
               "active"
             )}
           </div>
-        </div>
+        </button>
         <button
           onClick={goNext}
-          disabled={currentIndex <= 0}
-          className="p-2 hover:bg-sand-200 dark:hover:bg-charcoal-800 disabled:opacity-30 transition-colors touch-manipulation"
+          className="p-2 hover:bg-sand-200 dark:hover:bg-charcoal-800 transition-colors touch-manipulation"
           aria-label="Next month"
         >
           <ChevronRight size={20} />
@@ -83,18 +143,82 @@ export function MonthNav({
       </div>
 
       <div className="flex items-center gap-2 w-full sm:w-auto">
-        {selectedMonth.is_closed && (
-          <Button variant="ghost" size="sm" onClick={onDownloadPdf} className="flex-1 sm:flex-none">
-            <FileDown size={16} className="mr-2" />
-            PDF
-          </Button>
-        )}
-        {canClose && (
+        <Button variant="ghost" size="sm" onClick={onSummary} className="flex-1 sm:flex-none">
+          <PieChart size={16} className="mr-2" />
+          Summary
+        </Button>
+        {canClose ? (
           <Button variant="primary" size="sm" onClick={onClose} className="flex-1 sm:flex-none">
             Close Month
           </Button>
+        ) : (
+          <Button variant="ghost" size="sm" onClick={onReopen} className="flex-1 sm:flex-none">
+            Reopen
+          </Button>
         )}
       </div>
+
+      {showPicker && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setShowPicker(false)}>
+          <div 
+            className="bg-white dark:bg-charcoal-900 rounded-xl p-4 shadow-xl max-w-sm w-full mx-4"
+            onClick={e => e.stopPropagation()}
+          >
+            <div className="flex items-center justify-between mb-4">
+              <button
+                onClick={() => setPickerYear(y => y - 1)}
+                className="p-2 hover:bg-sand-200 dark:hover:bg-charcoal-800 rounded-lg transition-colors"
+              >
+                <ChevronLeft size={20} />
+              </button>
+              <span className="text-lg font-semibold text-charcoal-900 dark:text-sand-50">
+                {pickerYear}
+              </span>
+              <button
+                onClick={() => setPickerYear(y => y + 1)}
+                className="p-2 hover:bg-sand-200 dark:hover:bg-charcoal-800 rounded-lg transition-colors"
+              >
+                <ChevronRight size={20} />
+              </button>
+            </div>
+            <div className="grid grid-cols-3 gap-2">
+              {FULL_MONTH_NAMES.map((name, idx) => {
+                const monthNum = idx + 1;
+                const isSelected = selectedMonth?.year === pickerYear && selectedMonth?.month === monthNum;
+                const exists = months.some(m => m.year === pickerYear && m.month === monthNum);
+                
+                return (
+                  <button
+                    key={monthNum}
+                    onClick={() => handleMonthSelect(monthNum)}
+                    className={`
+                      p-2 rounded-lg text-sm font-medium transition-colors
+                      ${isSelected 
+                        ? "bg-sage-600 text-white" 
+                        : exists
+                          ? "bg-sand-200 dark:bg-charcoal-800 text-charcoal-900 dark:text-sand-50 hover:bg-sand-300 dark:hover:bg-charcoal-700"
+                          : "text-charcoal-600 dark:text-charcoal-400 hover:bg-sand-100 dark:hover:bg-charcoal-800"
+                      }
+                    `}
+                  >
+                    {name.slice(0, 3)}
+                  </button>
+                );
+              })}
+            </div>
+            <div className="mt-4 flex gap-2 text-xs text-charcoal-500 dark:text-charcoal-400">
+              <span className="flex items-center gap-1">
+                <span className="w-3 h-3 rounded bg-sand-200 dark:bg-charcoal-800"></span>
+                Existing
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="w-3 h-3 rounded border border-charcoal-300 dark:border-charcoal-600"></span>
+                New
+              </span>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/hooks/useMonth.ts
+++ b/frontend/src/hooks/useMonth.ts
@@ -46,9 +46,27 @@ export function useMonth() {
     loadMonth(monthId);
   };
 
+  const createMonth = async (year: number, month: number) => {
+    setLoading(true);
+    try {
+      const data = await api.months.create(year, month);
+      await loadMonths();
+      setSummary(data);
+      setSelectedMonthId(data.month.id);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const closeMonth = async () => {
     if (!selectedMonthId) return;
     await api.months.close(selectedMonthId);
+    await refresh();
+  };
+
+  const reopenMonth = async () => {
+    if (!selectedMonthId) return;
+    await api.months.reopen(selectedMonthId);
     await refresh();
   };
 
@@ -70,8 +88,10 @@ export function useMonth() {
     selectedMonthId,
     loading,
     selectMonth,
+    createMonth,
     refresh,
     closeMonth,
+    reopenMonth,
     downloadPdf,
     refreshTrigger,
   };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -97,3 +97,43 @@ select option {
   @apply bg-charcoal-900 text-sand-100;
 }
 
+@media print {
+  body {
+    background: white !important;
+    color: #1a1a1a !important;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  .print\:hidden {
+    display: none !important;
+  }
+
+  .print\:p-0 {
+    padding: 0 !important;
+  }
+
+  .print\:mb-4 {
+    margin-bottom: 1rem !important;
+  }
+
+  header,
+  .print-hide {
+    display: none !important;
+  }
+
+  main {
+    padding: 0 !important;
+    max-width: 100% !important;
+  }
+
+  .recharts-wrapper {
+    page-break-inside: avoid;
+  }
+
+  @page {
+    margin: 1cm;
+    size: A4;
+  }
+}
+

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -18,9 +18,10 @@ import { Loader2 } from "lucide-react";
 
 interface DashboardProps {
   onSettingsClick: () => void;
+  onSummaryClick: (monthId?: number) => void;
 }
 
-export function Dashboard({ onSettingsClick }: DashboardProps) {
+export function Dashboard({ onSettingsClick, onSummaryClick }: DashboardProps) {
   const [showVarianceModal, setShowVarianceModal] = useState(false);
   const { transfersEnabled } = useUIPreferences();
   const {
@@ -30,9 +31,10 @@ export function Dashboard({ onSettingsClick }: DashboardProps) {
     selectedMonthId,
     loading,
     selectMonth,
+    createMonth,
     refresh,
     closeMonth,
-    downloadPdf,
+    reopenMonth,
     refreshTrigger,
   } = useMonth();
 
@@ -65,8 +67,10 @@ export function Dashboard({ onSettingsClick }: DashboardProps) {
           months={months}
           selectedMonthId={selectedMonthId}
           onSelect={selectMonth}
+          onCreateMonth={createMonth}
           onClose={closeMonth}
-          onDownloadPdf={downloadPdf}
+          onReopen={reopenMonth}
+          onSummary={() => onSummaryClick(selectedMonthId ?? undefined)}
         />
         <div className="hidden lg:flex justify-end">
           <Stats />

--- a/frontend/src/pages/Summary.tsx
+++ b/frontend/src/pages/Summary.tsx
@@ -46,8 +46,24 @@ export function SummaryPage({ onBack, initialMonthId }: SummaryPageProps) {
   const contentRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
+    const loadInitialData = async () => {
+      setLoading(true);
+      try {
+        const [monthsList, currentMonth] = await Promise.all([
+          api.months.list(),
+          api.months.current(),
+        ]);
+        setMonths(monthsList);
+        setMonthSummary(currentMonth);
+        if (!initialMonthId) {
+          setSelectedMonthId(currentMonth.month.id);
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
     loadInitialData();
-  }, []);
+  }, [initialMonthId]);
 
   useEffect(() => {
     if (viewMode === "month" && selectedMonthId) {
@@ -56,23 +72,6 @@ export function SummaryPage({ onBack, initialMonthId }: SummaryPageProps) {
       loadYearData();
     }
   }, [viewMode, selectedMonthId]);
-
-  const loadInitialData = async () => {
-    setLoading(true);
-    try {
-      const [monthsList, currentMonth] = await Promise.all([
-        api.months.list(),
-        api.months.current(),
-      ]);
-      setMonths(monthsList);
-      setMonthSummary(currentMonth);
-      if (!selectedMonthId) {
-        setSelectedMonthId(currentMonth.month.id);
-      }
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const loadMonthData = async (monthId: number) => {
     setLoading(true);

--- a/frontend/src/pages/Summary.tsx
+++ b/frontend/src/pages/Summary.tsx
@@ -1,0 +1,500 @@
+import { useState, useEffect, useRef } from "react";
+import { ArrowLeft, Printer, Download, Calendar } from "lucide-react";
+import { Layout } from "../components/Layout";
+import { api, MonthSummary, StatsResponse, Month } from "../api/client";
+import { useCurrency } from "../context/CurrencyContext";
+import { Button } from "../components/ui/Button";
+import { Card } from "../components/ui/Card";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  Legend,
+} from "recharts";
+
+interface SummaryPageProps {
+  onBack: () => void;
+  initialMonthId?: number | null;
+}
+
+const MONTH_NAMES = [
+  "January", "February", "March", "April", "May", "June",
+  "July", "August", "September", "October", "November", "December",
+];
+
+const COLORS = [
+  "#5a7d5a", "#d4694a", "#6b8e8e", "#c4a35a", "#8b6b8e",
+  "#5a8e7d", "#8e6b5a", "#5a6b8e", "#8e8b5a", "#6b5a8e",
+];
+
+export function SummaryPage({ onBack, initialMonthId }: SummaryPageProps) {
+  const { formatCurrency } = useCurrency();
+  const [viewMode, setViewMode] = useState<"month" | "year">("month");
+  const [loading, setLoading] = useState(true);
+  const [months, setMonths] = useState<Month[]>([]);
+  const [selectedMonthId, setSelectedMonthId] = useState<number | null>(initialMonthId ?? null);
+  const [monthSummary, setMonthSummary] = useState<MonthSummary | null>(null);
+  const [yearStats, setYearStats] = useState<StatsResponse | null>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    loadInitialData();
+  }, []);
+
+  useEffect(() => {
+    if (viewMode === "month" && selectedMonthId) {
+      loadMonthData(selectedMonthId);
+    } else if (viewMode === "year") {
+      loadYearData();
+    }
+  }, [viewMode, selectedMonthId]);
+
+  const loadInitialData = async () => {
+    setLoading(true);
+    try {
+      const [monthsList, currentMonth] = await Promise.all([
+        api.months.list(),
+        api.months.current(),
+      ]);
+      setMonths(monthsList);
+      setMonthSummary(currentMonth);
+      if (!selectedMonthId) {
+        setSelectedMonthId(currentMonth.month.id);
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadMonthData = async (monthId: number) => {
+    setLoading(true);
+    try {
+      const data = await api.months.get(monthId);
+      setMonthSummary(data);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadYearData = async () => {
+    setLoading(true);
+    try {
+      const data = await api.stats.get();
+      setYearStats(data);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePrint = () => {
+    window.print();
+  };
+
+  const handleDownloadImage = async () => {
+    if (!contentRef.current) return;
+    try {
+      const html2canvas = (await import("html2canvas")).default;
+      const canvas = await html2canvas(contentRef.current, {
+        backgroundColor: "#faf8f5",
+        scale: 2,
+      });
+      const link = document.createElement("a");
+      link.download = viewMode === "month" 
+        ? `summary-${monthSummary?.month.year}-${monthSummary?.month.month}.png`
+        : `summary-${new Date().getFullYear()}.png`;
+      link.href = canvas.toDataURL("image/png");
+      link.click();
+    } catch (error) {
+      console.error("Failed to generate image:", error);
+    }
+  };
+
+  const selectedMonth = months.find(m => m.id === selectedMonthId);
+
+  const spendingByCategory = monthSummary?.items
+    .filter(i => i.savings_destination === "none")
+    .reduce((acc, item) => {
+      const existing = acc.find(c => c.category === item.category_label);
+      if (existing) {
+        existing.amount += item.amount;
+      } else {
+        acc.push({ category: item.category_label, amount: item.amount });
+      }
+      return acc;
+    }, [] as { category: string; amount: number }[])
+    .sort((a, b) => b.amount - a.amount) || [];
+
+  const budgetVsActual = monthSummary?.budgets
+    .map(b => ({
+      category: b.category_label,
+      budget: b.allocated_amount,
+      actual: b.spent_amount,
+      diff: b.allocated_amount - b.spent_amount,
+    }))
+    .filter(b => b.budget > 0 || b.actual > 0)
+    .sort((a, b) => b.actual - a.actual) || [];
+
+  const topSpending = monthSummary?.items
+    .filter(i => i.savings_destination === "none")
+    .sort((a, b) => b.amount - a.amount)
+    .slice(0, 10) || [];
+
+  const incomeBreakdown = monthSummary?.income_entries
+    .map(e => ({ name: e.label, value: e.amount })) || [];
+
+  const monthlyTrends = yearStats?.monthly_trends
+    .slice()
+    .reverse()
+    .map(m => ({
+      name: `${MONTH_NAMES[m.month - 1].slice(0, 3)}`,
+      income: m.total_income,
+      spent: m.total_spent,
+      net: m.net,
+    })) || [];
+
+  const yearTotals = yearStats?.monthly_trends.reduce(
+    (acc, m) => ({
+      income: acc.income + m.total_income,
+      spent: acc.spent + m.total_spent,
+      fixed: acc.fixed + m.total_fixed,
+      net: acc.net + m.net,
+    }),
+    { income: 0, spent: 0, fixed: 0, net: 0 }
+  ) || { income: 0, spent: 0, fixed: 0, net: 0 };
+
+  const savingsRate = monthSummary 
+    ? ((monthSummary.total_income - monthSummary.total_fixed - monthSummary.total_spent) / monthSummary.total_income * 100)
+    : 0;
+
+  return (
+    <Layout>
+      <div className="print:hidden mb-6">
+        <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
+          <button
+            onClick={onBack}
+            className="flex items-center gap-2 text-charcoal-600 dark:text-charcoal-400 hover:text-charcoal-900 dark:hover:text-sand-100"
+          >
+            <ArrowLeft size={20} />
+            Back to Dashboard
+          </button>
+          <div className="flex items-center gap-2">
+            <Button variant="ghost" size="sm" onClick={handlePrint}>
+              <Printer size={16} className="mr-2" />
+              Print PDF
+            </Button>
+            <Button variant="ghost" size="sm" onClick={handleDownloadImage}>
+              <Download size={16} className="mr-2" />
+              Save Image
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <div className="print:hidden mb-6 flex flex-col sm:flex-row items-start sm:items-center gap-4">
+        <div className="flex rounded-lg overflow-hidden border border-sand-300 dark:border-charcoal-700">
+          <button
+            onClick={() => setViewMode("month")}
+            className={`px-4 py-2 text-sm font-medium transition-colors ${
+              viewMode === "month"
+                ? "bg-sage-600 text-white"
+                : "bg-sand-100 dark:bg-charcoal-800 text-charcoal-900 dark:text-sand-300 hover:bg-sand-200 dark:hover:bg-charcoal-700"
+            }`}
+          >
+            Single Month
+          </button>
+          <button
+            onClick={() => setViewMode("year")}
+            className={`px-4 py-2 text-sm font-medium transition-colors ${
+              viewMode === "year"
+                ? "bg-sage-600 text-white"
+                : "bg-sand-100 dark:bg-charcoal-800 text-charcoal-900 dark:text-sand-300 hover:bg-sand-200 dark:hover:bg-charcoal-700"
+            }`}
+          >
+            Full Year
+          </button>
+        </div>
+
+        {viewMode === "month" && (
+          <div className="flex items-center gap-2">
+            <Calendar size={16} className="text-charcoal-500" />
+            <select
+              value={selectedMonthId ?? ""}
+              onChange={(e) => setSelectedMonthId(Number(e.target.value))}
+              className="px-3 py-2 rounded-lg border border-sand-300 dark:border-charcoal-700 bg-white dark:bg-charcoal-800 text-charcoal-900 dark:text-sand-100 text-sm"
+            >
+              {months.map(m => (
+                <option key={m.id} value={m.id}>
+                  {MONTH_NAMES[m.month - 1]} {m.year}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
+      </div>
+
+      <div ref={contentRef} className="space-y-6 bg-sand-50 dark:bg-charcoal-950 p-4 print:p-0">
+        <div className="text-center mb-8 print:mb-4">
+          <h1 className="text-2xl sm:text-3xl font-bold text-charcoal-900 dark:text-sand-50">
+            {viewMode === "month" && selectedMonth
+              ? `${MONTH_NAMES[selectedMonth.month - 1]} ${selectedMonth.year} Summary`
+              : `${new Date().getFullYear()} Year Summary`}
+          </h1>
+          <p className="text-sm text-charcoal-500 dark:text-charcoal-400 mt-1">
+            Generated on {new Date().toLocaleDateString()}
+          </p>
+        </div>
+
+        {loading ? (
+          <div className="py-12 text-center text-charcoal-500">Loading...</div>
+        ) : viewMode === "month" && monthSummary ? (
+          <>
+            <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 sm:gap-4">
+              <Card>
+                <div className="text-xs text-charcoal-500 dark:text-charcoal-400 mb-1">Total Income</div>
+                <div className="text-lg font-semibold text-sage-600 dark:text-sage-400">
+                  {formatCurrency(monthSummary.total_income)}
+                </div>
+              </Card>
+              <Card>
+                <div className="text-xs text-charcoal-500 dark:text-charcoal-400 mb-1">Fixed Expenses</div>
+                <div className="text-lg font-semibold text-charcoal-600 dark:text-charcoal-400">
+                  {formatCurrency(monthSummary.total_fixed)}
+                </div>
+              </Card>
+              <Card>
+                <div className="text-xs text-charcoal-500 dark:text-charcoal-400 mb-1">Total Spent</div>
+                <div className="text-lg font-semibold text-terracotta-600 dark:text-terracotta-400">
+                  {formatCurrency(monthSummary.total_spent)}
+                </div>
+              </Card>
+              <Card>
+                <div className="text-xs text-charcoal-500 dark:text-charcoal-400 mb-1">Remaining</div>
+                <div className={`text-lg font-semibold ${monthSummary.remaining >= 0 ? "text-sage-600 dark:text-sage-400" : "text-terracotta-600 dark:text-terracotta-400"}`}>
+                  {formatCurrency(monthSummary.remaining)}
+                </div>
+              </Card>
+              <Card>
+                <div className="text-xs text-charcoal-500 dark:text-charcoal-400 mb-1">Savings Rate</div>
+                <div className={`text-lg font-semibold ${savingsRate >= 0 ? "text-sage-600 dark:text-sage-400" : "text-terracotta-600 dark:text-terracotta-400"}`}>
+                  {savingsRate.toFixed(1)}%
+                </div>
+              </Card>
+            </div>
+
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+              {spendingByCategory.length > 0 && (
+                <Card>
+                  <h3 className="text-sm font-medium text-charcoal-700 dark:text-sand-200 mb-4">
+                    Spending by Category
+                  </h3>
+                  <div className="h-64">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <PieChart>
+                        <Pie
+                          data={spendingByCategory}
+                          dataKey="amount"
+                          nameKey="category"
+                          cx="30%"
+                          cy="50%"
+                          outerRadius={70}
+                        >
+                          {spendingByCategory.map((_, index) => (
+                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                          ))}
+                        </Pie>
+                        <Tooltip
+                          formatter={(value) => formatCurrency(Number(value))}
+                          contentStyle={{ backgroundColor: "#faf8f5", border: "none", fontSize: 12, color: "#1a1a1a" }}
+                        />
+                        <Legend layout="vertical" align="right" verticalAlign="middle" wrapperStyle={{ fontSize: 10 }} />
+                      </PieChart>
+                    </ResponsiveContainer>
+                  </div>
+                </Card>
+              )}
+
+              {incomeBreakdown.length > 0 && (
+                <Card>
+                  <h3 className="text-sm font-medium text-charcoal-700 dark:text-sand-200 mb-4">
+                    Income Sources
+                  </h3>
+                  <div className="h-64">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <PieChart>
+                        <Pie
+                          data={incomeBreakdown}
+                          dataKey="value"
+                          nameKey="name"
+                          cx="30%"
+                          cy="50%"
+                          outerRadius={70}
+                        >
+                          {incomeBreakdown.map((_, index) => (
+                            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                          ))}
+                        </Pie>
+                        <Tooltip
+                          formatter={(value) => formatCurrency(Number(value))}
+                          contentStyle={{ backgroundColor: "#faf8f5", border: "none", fontSize: 12, color: "#1a1a1a" }}
+                        />
+                        <Legend layout="vertical" align="right" verticalAlign="middle" wrapperStyle={{ fontSize: 10 }} />
+                      </PieChart>
+                    </ResponsiveContainer>
+                  </div>
+                </Card>
+              )}
+            </div>
+
+            {budgetVsActual.length > 0 && (
+              <Card>
+                <h3 className="text-sm font-medium text-charcoal-700 dark:text-sand-200 mb-4">
+                  Budget vs Actual
+                </h3>
+                <div className="h-80">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart data={budgetVsActual} layout="vertical" margin={{ left: 80 }}>
+                      <XAxis type="number" tick={{ fontSize: 10 }} />
+                      <YAxis type="category" dataKey="category" tick={{ fontSize: 10 }} width={75} />
+                      <Tooltip
+                        formatter={(value) => formatCurrency(Number(value))}
+                        contentStyle={{ backgroundColor: "#faf8f5", border: "none", fontSize: 12, color: "#1a1a1a" }}
+                      />
+                      <Legend />
+                      <Bar dataKey="budget" fill="#5a7d5a" name="Budget" />
+                      <Bar dataKey="actual" fill="#d4694a" name="Actual" />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              </Card>
+            )}
+
+            {topSpending.length > 0 && (
+              <Card>
+                <h3 className="text-sm font-medium text-charcoal-700 dark:text-sand-200 mb-4">
+                  Top 10 Expenses
+                </h3>
+                <div className="h-80">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart
+                      data={topSpending.map(i => ({ name: i.description.slice(0, 20), amount: i.amount, category: i.category_label }))}
+                      layout="vertical"
+                      margin={{ left: 100 }}
+                    >
+                      <XAxis type="number" tick={{ fontSize: 10 }} />
+                      <YAxis type="category" dataKey="name" tick={{ fontSize: 10 }} width={95} />
+                      <Tooltip
+                        formatter={(value) => formatCurrency(Number(value))}
+                        labelFormatter={(label) => {
+                          const item = topSpending.find(i => i.description.slice(0, 20) === label);
+                          return item ? `${item.description} (${item.category_label})` : String(label);
+                        }}
+                        contentStyle={{ backgroundColor: "#faf8f5", border: "none", fontSize: 12, color: "#1a1a1a" }}
+                      />
+                      <Bar dataKey="amount" fill="#6b8e8e" />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              </Card>
+            )}
+          </>
+        ) : viewMode === "year" && yearStats ? (
+          <>
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4">
+              <Card>
+                <div className="text-xs text-charcoal-500 dark:text-charcoal-400 mb-1">Total Earned</div>
+                <div className="text-lg font-semibold text-sage-600 dark:text-sage-400">
+                  {formatCurrency(yearTotals.income)}
+                </div>
+              </Card>
+              <Card>
+                <div className="text-xs text-charcoal-500 dark:text-charcoal-400 mb-1">Total Spent</div>
+                <div className="text-lg font-semibold text-terracotta-600 dark:text-terracotta-400">
+                  {formatCurrency(yearTotals.spent + yearTotals.fixed)}
+                </div>
+              </Card>
+              <Card>
+                <div className="text-xs text-charcoal-500 dark:text-charcoal-400 mb-1">Total Saved</div>
+                <div className={`text-lg font-semibold ${yearTotals.net >= 0 ? "text-sage-600 dark:text-sage-400" : "text-terracotta-600 dark:text-terracotta-400"}`}>
+                  {formatCurrency(yearTotals.net)}
+                </div>
+              </Card>
+              <Card>
+                <div className="text-xs text-charcoal-500 dark:text-charcoal-400 mb-1">Avg Monthly</div>
+                <div className="text-lg font-semibold text-charcoal-600 dark:text-charcoal-400">
+                  {formatCurrency(yearStats.average_monthly_spending)}
+                </div>
+              </Card>
+            </div>
+
+            {monthlyTrends.length > 1 && (
+              <Card>
+                <h3 className="text-sm font-medium text-charcoal-700 dark:text-sand-200 mb-4">
+                  Monthly Trends
+                </h3>
+                <div className="h-80">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <AreaChart data={monthlyTrends}>
+                      <XAxis dataKey="name" tick={{ fontSize: 10 }} />
+                      <YAxis tick={{ fontSize: 10 }} />
+                      <Tooltip
+                        formatter={(value) => formatCurrency(Number(value))}
+                        contentStyle={{ backgroundColor: "#faf8f5", border: "none", fontSize: 12, color: "#1a1a1a" }}
+                      />
+                      <Legend />
+                      <Area type="monotone" dataKey="income" stroke="#5a7d5a" fill="#5a7d5a" fillOpacity={0.3} name="Income" />
+                      <Area type="monotone" dataKey="spent" stroke="#d4694a" fill="#d4694a" fillOpacity={0.3} name="Spent" />
+                      <Area type="monotone" dataKey="net" stroke="#6b8e8e" fill="#6b8e8e" fillOpacity={0.3} name="Net" />
+                    </AreaChart>
+                  </ResponsiveContainer>
+                </div>
+              </Card>
+            )}
+
+            {yearStats.category_comparisons.length > 0 && (
+              <Card>
+                <h3 className="text-sm font-medium text-charcoal-700 dark:text-sand-200 mb-4">
+                  Category Spending This Month vs Last
+                </h3>
+                <div className="h-80">
+                  <ResponsiveContainer width="100%" height="100%">
+                    <BarChart
+                      data={yearStats.category_comparisons.map(c => ({
+                        category: c.category_label,
+                        current: c.current_month_spent,
+                        previous: c.previous_month_spent,
+                      }))}
+                      layout="vertical"
+                      margin={{ left: 80 }}
+                    >
+                      <XAxis type="number" tick={{ fontSize: 10 }} />
+                      <YAxis type="category" dataKey="category" tick={{ fontSize: 10 }} width={75} />
+                      <Tooltip
+                        formatter={(value) => formatCurrency(Number(value))}
+                        contentStyle={{ backgroundColor: "#faf8f5", border: "none", fontSize: 12, color: "#1a1a1a" }}
+                      />
+                      <Legend />
+                      <Bar dataKey="current" fill="#5a7d5a" name="This Month" />
+                      <Bar dataKey="previous" fill="#c4a35a" name="Last Month" />
+                    </BarChart>
+                  </ResponsiveContainer>
+                </div>
+              </Card>
+            )}
+          </>
+        ) : (
+          <div className="py-12 text-center text-charcoal-500">
+            No data available
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
Multi-month navigation allowing users to browse and create months for any year via a picker modal and arrow navigation. 

This PR also introduces a Summary page with interactive charts including spending breakdowns, income sources, budget vs actual comparisons, and monthly trends with options for single month or full year views. Also adds the ability to reopen closed months and export the summary as a browser-printed PDF or image.