### PR TITLE
added Settings to Summary page navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -13,6 +13,7 @@ export default function App() {
   const [showSettings, setShowSettings] = useState(false);
   const [showSummary, setShowSummary] = useState(false);
   const [summaryMonthId, setSummaryMonthId] = useState<number | null>(null);
+  const [settingsFrom, setSettingsFrom] = useState<"dashboard" | "summary">("dashboard");
 
   if (loading) {
     return (
@@ -31,13 +32,27 @@ export default function App() {
   }
 
   if (showSettings) {
-    return <Settings onBack={() => setShowSettings(false)} />;
+    return (
+      <Settings
+        from={settingsFrom}
+        onBack={() => {
+          setShowSettings(false);
+          if (settingsFrom === "summary") {
+            setShowSummary(true);
+          }
+        }}
+      />
+    );
   }
 
   if (showSummary) {
     return (
       <SummaryPage
         onBack={() => setShowSummary(false)}
+        onSettingsClick={() => {
+          setSettingsFrom("summary");
+          setShowSettings(true);
+        }}
         initialMonthId={summaryMonthId}
       />
     );
@@ -45,7 +60,10 @@ export default function App() {
 
   return (
     <Dashboard
-      onSettingsClick={() => setShowSettings(true)}
+      onSettingsClick={() => {
+        setSettingsFrom("dashboard");
+        setShowSettings(true);
+      }}
       onSummaryClick={(monthId) => {
         setSummaryMonthId(monthId ?? null);
         setShowSummary(true);

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -12,9 +12,10 @@ import { ArrowLeft, Info } from "lucide-react";
 
 interface SettingsProps {
   onBack: () => void;
+  from?: "dashboard" | "summary";
 }
 
-export function Settings({ onBack }: SettingsProps) {
+export function Settings({ onBack, from = "dashboard" }: SettingsProps) {
   const { user, logout, updateUsername } = useAuth();
   const { currency, setCurrency, formatCurrency } = useCurrency();
   const { transfersEnabled, setTransfersEnabled } = useUIPreferences();
@@ -121,7 +122,7 @@ export function Settings({ onBack }: SettingsProps) {
           className="mb-4 sm:mb-6 flex items-center gap-2 text-sm text-charcoal-600 dark:text-charcoal-400 hover:text-charcoal-900 dark:hover:text-sand-100 transition-colors touch-manipulation"
         >
           <ArrowLeft size={16} />
-          Back to Dashboard
+          Back to {from === "summary" ? "Summary" : "Dashboard"}
         </button>
 
         <h1 className="text-xl sm:text-2xl font-semibold mb-6 sm:mb-8 text-charcoal-800 dark:text-sand-100">

--- a/frontend/src/pages/Summary.tsx
+++ b/frontend/src/pages/Summary.tsx
@@ -22,6 +22,7 @@ import {
 
 interface SummaryPageProps {
   onBack: () => void;
+  onSettingsClick: () => void;
   initialMonthId?: number | null;
 }
 
@@ -35,7 +36,7 @@ const COLORS = [
   "#5a8e7d", "#8e6b5a", "#5a6b8e", "#8e8b5a", "#6b5a8e",
 ];
 
-export function SummaryPage({ onBack, initialMonthId }: SummaryPageProps) {
+export function SummaryPage({ onBack, onSettingsClick, initialMonthId }: SummaryPageProps) {
   const { formatCurrency } = useCurrency();
   const [viewMode, setViewMode] = useState<"month" | "year">("month");
   const [loading, setLoading] = useState(true);
@@ -174,7 +175,7 @@ export function SummaryPage({ onBack, initialMonthId }: SummaryPageProps) {
     : 0;
 
   return (
-    <Layout>
+    <Layout onSettingsClick={onSettingsClick}>
       <div className="print:hidden mb-6">
         <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
           <button


### PR DESCRIPTION
Noticed the summary page was missing the settings option,