### PR TITLE
docs: add documentation for HealthResponse struct

### DIFF
--- a/backend/src/handlers/health.rs
+++ b/backend/src/handlers/health.rs
@@ -2,9 +2,12 @@ use axum::{extract::State, http::StatusCode, Json};
 use serde::Serialize;
 use sqlx::SqlitePool;
 
+/// Represents the response for the health check endpoint.
 #[derive(Serialize)]
 pub struct HealthResponse {
+    /// The overall health status of the service, typically "healthy" when operational.
     pub status: &'static str,
+    /// The status of the database connection, either "connected" or "disconnected".
     pub database: &'static str,
 }
 


### PR DESCRIPTION
### 问题背景

`HealthResponse` 是一个用于健康检查端点（`/health`）的公共结构体。它目前缺乏任何文档注释（docstrings），这降低了代码的可维护性和可读性。为公共 API 元素添加清晰的文档是 Rust 社区的最佳实践，有助于其他开发者（和未来的自己）快速理解其用途和内部字段的含义。

### 修改内容

- **为 `HealthResponse` 结构体添加了文档注释**：解释了该结构体代表健康检查端点的响应。
- **为 `status` 字段添加了文档注释**：说明了该字段表示服务的整体健康状态，通常在运行正常时为 `"healthy"`。
- **为 `database` 字段添加了文档注释**：说明了该字段表示数据库连接的状态，取值为 `"connected"` 或 `"disconnected"`。

这些文档注释是直接的、描述性的，旨在准确解释每个元素的用途和取值范围，而无需修改任何功能逻辑。

### 验证方式

- **功能验证**：此修改仅为添加文档注释，未更改任何代码逻辑。因此，现有的所有测试（如果存在）应继续通过。
- **手动验证**：可以通过 `cargo doc --open` 在本地生成并查看文档，确认新增的注释正确显示。

### 其他信息

- **Breaking Changes**：无。此变更仅添加文档，不改变任何公共 API 或内部行为。
- **文档更新**：本 PR 本身即是文档更新。代码中新增的注释会自动包含在由 `cargo doc` 生成的 API 文档中。
- **已知限制**：无。